### PR TITLE
🎬 `idiomatic_version_file_enable_tools` の無効化

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,5 +3,5 @@ uv = "latest"
 actionlint = "latest"
 pre-commit = "latest"
 
-[tasks.actionlint]
-run = "actionlint"
+[settings]
+idiomatic_version_file_enable_tools = []


### PR DESCRIPTION
# 概要
uv が生成している `.python_version` というファイルが原因となって mise が以下の警告を発しているため、抑制のために設定ファイルを修正した。

>mise WARN  deprecated [idiomatic_version_file_enable_tools]: 
Idiomatic version files like ~/work/20250803_gha_sample/20250803_gha_sample/.python-version are currently enabled by default. However, this will change in mise 2025.[10](https://github.com/keishi-hashimoto/20250803_gha_sample/actions/runs/16698619903/job/47266231956#step:5:11).0 to instead default to disabled.